### PR TITLE
メッセージ自動更新機能の追加

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -66,4 +66,38 @@ $(function(){
       $('.main-chat__message-form__btn').prop('disabled', false);
     })
   })
+  
+ //メッセージ自動更新
+  $(function() {
+    function update() {
+      let last_message_id = $('.message:last').data("message-id");
+      $.ajax({
+        type: 'GET',
+        url: 'api/messages',
+        data: {id: last_message_id},
+        dataType: 'json'
+      })
+      .done(function(messages) {
+        if (messages.length !== 0) {
+          let containHTML = '';
+          $.each(messages, function(i, message){
+            containHTML += buildHTML(message)
+          });
+          $('.main-chat__message-list').append(containHTML);
+          $('.main-chat__message-list').animate({ scrollTop: $('.main-chat__message-list')[0].scrollHeight});
+          $('#new_message')[0].reset();
+          $(".main-chat__message-form__btn").prop("disabled", false);
+        }
+      })
+      .fail(function() {
+        alert('メッセージの自動更新に失敗しました');
+      });
+    }
+
+    $(function() {
+      if (document.location.href.match(/\/groups\/\d+\/messages/)){
+        setInterval(update, 6000);
+      }
+    });
+  });
 });

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -96,7 +96,7 @@ $(function(){
 
     $(function() {
       if (document.location.href.match(/\/groups\/\d+\/messages/)){
-        setInterval(update, 6000);
+        setInterval(update, 7000);
       }
     });
   });

--- a/app/controllers/api/message_controller.rb
+++ b/app/controllers/api/message_controller.rb
@@ -1,0 +1,7 @@
+class Api::MessageController < ApplicationController
+  def index
+    group = Group.find(params[:group_id])
+    last_message_id = params[:id].to_i
+    @messages = group.messages.includes(:user).where("id > #{last_message_id}")
+  end
+end

--- a/app/controllers/api/messages_controller.rb
+++ b/app/controllers/api/messages_controller.rb
@@ -1,4 +1,4 @@
-class Api::MessageController < ApplicationController
+class Api::MessagesController < ApplicationController
   def index
     group = Group.find(params[:group_id])
     last_message_id = params[:id].to_i

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,0 +1,7 @@
+json.array! @messages do |message|
+  json.content message.content
+  json.image message.image.url
+  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.user_name message.user.name
+  json.id message.id
+end

--- a/app/views/api/messages/index.json.jbuilder
+++ b/app/views/api/messages/index.json.jbuilder
@@ -1,7 +1,7 @@
 json.array! @messages do |message|
   json.content message.content
   json.image message.image.url
-  json.created_at message.created_at.strftime("%Y年%m月%d日 %H時%M分")
+  json.created_at message.created_at.strftime("%y/%m/%d(%a) %H:%M:%S")
   json.user_name message.user.name
   json.id message.id
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -1,4 +1,4 @@
-.message{"data-message-id": "#{message.id}"}
+.message{data: {message: {id: message.id}}}
   .main-chat__message-list__box
     .main-chat__message-list__box__user
       = message.user.name

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,5 +1,5 @@
 json.user_name @message.user.name
 json.content @message.content
 json.image @message.image_url
-json.created_at @message.created_at.strftime("%y年%m月%d日 %H時%M分")
+json.created_at @message.created_at.strftime("%y/%m/%d(%a) %H:%M:%S")
 json.id @message.id

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -2,3 +2,4 @@ json.user_name @message.user.name
 json.content @message.content
 json.image @message.image_url
 json.created_at @message.created_at.strftime("%y年%m月%d日 %H時%M分")
+json.id @message.id

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,9 +7,8 @@ Rails.application.routes.draw do
   resources :users, only: [:index, :edit, :update]
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
-  end
-
-  namespace :api do
-    resources :messages, only: :index, defaults: { format: 'json' }
+    namespace :api do
+      resources :messages, only: :index, defaults: { format: 'json' }
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,4 +8,8 @@ Rails.application.routes.draw do
   resources :groups, only: [:new, :create, :edit, :update] do
     resources :messages, only: [:index, :create]
   end
+
+  namespace :api do
+    resources :messages, only: :index, defaults: { format: 'json' }
+  end
 end


### PR DESCRIPTION
#What
メッセージ画面を自動更新することで、いかなるユーザーが送信したメッセージでも自動で追加表示されるようにする。

#Why
現状では、同じグループのユーザーが見る別ブラウザには、メッセージが反映されないため。
https://gyazo.com/18bc119a3b9fd0a060afc29a317585e7